### PR TITLE
Bid sort

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -66,6 +66,14 @@ contract Escrow is ProtocolVerifier, SafetyLocks, SearcherWrapper {
         nextNonce = uint256(_escrowData[searcherMetaTxSigner].nonce) + 1;
     }
 
+    function searcherEscrowBalance(address searcherMetaTxSigner) external view returns (uint256 balance) {
+        balance = uint256(_escrowData[searcherMetaTxSigner].total);
+    }
+
+    function searcherLastActiveBlock(address searcherMetaTxSigner) external view returns (uint256 lastBlock) {
+        lastBlock = uint256(_escrowData[searcherMetaTxSigner].lastAccessed);
+    }
+
     ///////////////////////////////////////////////////
     /// EXTERNAL FUNCTIONS FOR BUNDLER INTERACTION  ///
     ///////////////////////////////////////////////////
@@ -133,18 +141,18 @@ contract Escrow is ProtocolVerifier, SafetyLocks, SearcherWrapper {
     ///////////////////////////////////////////////////
     function _executeStagingCall(
         ProtocolCall calldata protocolCall,
-        UserMetaTx calldata userCall,
+        UserMetaTx calldata userMetaTx,
         address environment
     ) internal stagingLock(protocolCall, environment) returns (bytes memory stagingReturnData) {
-        stagingReturnData = IExecutionEnvironment(environment).stagingWrapper{value: msg.value}(userCall);
+        stagingReturnData = IExecutionEnvironment(environment).stagingWrapper{value: msg.value}(userMetaTx);
     }
 
-    function _executeUserCall(UserMetaTx calldata userCall, address environment)
+    function _executeUserCall(UserMetaTx calldata userMetaTx, address environment)
         internal
-        userLock(userCall, environment)
+        userLock(userMetaTx, environment)
         returns (bytes memory userReturnData)
     {
-        userReturnData = IExecutionEnvironment(environment).userWrapper(userCall);
+        userReturnData = IExecutionEnvironment(environment).userWrapper(userMetaTx);
     }
 
     function _executeSearcherCall(

--- a/src/contracts/atlas/ExecutionEnvironment.sol
+++ b/src/contracts/atlas/ExecutionEnvironment.sol
@@ -61,18 +61,18 @@ contract ExecutionEnvironment is Test {
     //////////////////////////////////
     ///    CORE CALL FUNCTIONS     ///
     //////////////////////////////////
-    function stagingWrapper(UserMetaTx calldata userCall)
+    function stagingWrapper(UserMetaTx calldata userMetaTx)
         external
         returns (bytes memory)
     {
         // msg.sender = atlas
         // address(this) = ExecutionEnvironment
 
-        require(msg.sender == atlas && userCall.from == _user(), "ERR-CE00 InvalidSenderStaging");
-        require(userCall.to != address(this), "ERR-EV008 InvalidTo");
+        require(msg.sender == atlas && userMetaTx.from == _user(), "ERR-CE00 InvalidSenderStaging");
+        require(userMetaTx.to != address(this), "ERR-EV008 InvalidTo");
 
         bytes memory stagingData = abi.encodeWithSelector(
-            IProtocolControl.stagingCall.selector, userCall.to, userCall.from, bytes4(userCall.data), userCall.data[4:]
+            IProtocolControl.stagingCall.selector, userMetaTx
         );
 
 

--- a/src/contracts/atlas/Sequencer.sol
+++ b/src/contracts/atlas/Sequencer.sol
@@ -1,0 +1,198 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import {IExecutionEnvironment} from "../interfaces/IExecutionEnvironment.sol";
+import {IAtlas} from "../interfaces/IAtlas.sol";
+import {IEscrow} from "../interfaces/IEscrow.sol";
+import {IProtocolControl} from "../interfaces/IProtocolControl.sol";
+
+import "../types/CallTypes.sol";
+
+import {CallBits} from "../libraries/CallBits.sol";
+import {CallVerification} from "../libraries/CallVerification.sol";
+
+contract Sequencer {
+
+    address immutable public atlas;
+    address immutable public escrow;
+
+    constructor(address _atlas, address _escrow) {
+        atlas = _atlas;
+        escrow = _escrow;
+    }
+
+    struct SortingData {
+        uint256 amount;
+        bool valid;
+    }
+
+    function sequence(
+        UserCall calldata userCall, 
+        SearcherCall[] calldata searcherCalls
+    ) external view returns (SearcherCall[] memory) {
+
+        ProtocolCall memory protocolCall = IProtocolControl(userCall.metaTx.control).getProtocolCall();
+
+        uint256 count = searcherCalls.length;
+
+        (SortingData[] memory sortingData, uint256 invalid) = _getSortingData(
+            protocolCall, userCall, searcherCalls, count);
+
+        uint256[] memory sorted = _sort(sortingData, count, invalid);
+
+        SearcherCall[] memory searcherCallsSorted = new SearcherCall[](count - invalid);
+
+        count -= invalid;
+        uint256 i = 0;
+
+        for (;i<count;) {
+            searcherCallsSorted[i] = searcherCalls[sorted[i]];
+            unchecked { ++i; }
+        }
+
+        return searcherCallsSorted;
+    }
+
+    function _verifyBidFormat(
+        BidData[] memory bidFormat, 
+        SearcherCall calldata searcherCall
+    ) internal pure returns (bool) {
+        uint256 count = bidFormat.length;
+        if (searcherCall.bids.length != count) {
+            return false;
+        }
+
+        uint256 i;
+        for (;i<count;) {
+            if (searcherCall.bids[i].token != bidFormat[i].token) {
+                return false;
+            }
+            unchecked{ ++i; }
+        }
+        return true;
+    }
+
+    function _verifySearcherEligibility(
+        ProtocolCall memory protocolCall,
+        UserMetaTx calldata userMetaTx, 
+        SearcherCall calldata searcherCall
+    ) internal view returns (bool) {
+        // Verify that the searcher submitted the correct callhash
+        bytes32 userCallHash = CallVerification.getUserCallHash(userMetaTx);
+        if (searcherCall.metaTx.userCallHash != userCallHash) {
+            return false;
+        }
+
+        // Make sure the searcher has enough funds escrowed
+        // TODO: subtract any pending withdrawals
+        uint256 searcherBalance = IEscrow(escrow).searcherEscrowBalance(searcherCall.metaTx.from);
+        if (searcherBalance < searcherCall.metaTx.maxFeePerGas * searcherCall.metaTx.gas) {
+            return false;
+        }
+
+        // Searchers can only do one tx per block - this prevents double counting escrow balances.
+        // TODO: Add in "targetBlockNumber" as an arg?
+        uint256 searcherLastActiveBlock = IEscrow(escrow).searcherLastActiveBlock(searcherCall.metaTx.from);
+        if (searcherLastActiveBlock >= block.number) {
+            return false;
+        }
+
+        // Make sure the searcher nonce is accurate
+        uint256 nextSearcherNonce = IEscrow(escrow).nextSearcherNonce(searcherCall.metaTx.from);
+        if (nextSearcherNonce != searcherCall.metaTx.nonce) {
+            return false;
+        }
+
+        // Make sure that the searcher has the correct codehash for protocol control contract
+        if (protocolCall.to.codehash != searcherCall.metaTx.controlCodeHash) {
+            return false;
+        }
+
+        // Make sure that the searcher's maxFeePerGas matches or exceeds the user's
+        if (searcherCall.metaTx.maxFeePerGas < userMetaTx.maxFeePerGas) {
+            return false;
+        }
+
+        return true;
+    }
+
+    function _getSortingData(
+        ProtocolCall memory protocolCall, 
+        UserCall calldata userCall, 
+        SearcherCall[] calldata searcherCalls,
+        uint256 count
+    ) internal view returns (SortingData[] memory, uint256){
+
+        BidData[] memory bidFormat = IProtocolControl(protocolCall.to).getBidFormat(userCall.metaTx);
+
+        SortingData[] memory sortingData = new SortingData[](count);
+
+        uint256 i;
+        uint256 invalid;
+        for (;i<count;) {
+            if (
+                _verifyBidFormat(bidFormat, searcherCalls[i]) && 
+                _verifySearcherEligibility(protocolCall, userCall.metaTx, searcherCalls[i])
+            ) {
+                sortingData[i] = SortingData({
+                    amount: IProtocolControl(protocolCall.to).getBidValue(searcherCalls[i]),
+                    valid: true
+                });
+                
+
+            } else {
+                sortingData[i] = SortingData({
+                    amount: 0,
+                    valid: false
+                });
+                unchecked{ ++invalid; }
+            }
+            unchecked{ ++i; }            
+        }
+
+        return (sortingData, invalid);
+    }
+
+    function _sort(
+        SortingData[] memory sortingData,
+        uint256 count,
+        uint256 invalid
+    ) internal pure returns (uint256[] memory) {
+
+        uint256[] memory sorted = new uint256[](count - invalid);
+
+        uint256 n; // outer loop counter
+        uint256 i; // inner loop counter
+
+        uint256 topBid;
+        uint256 bottomBid;
+
+        for (;invalid<count;) {
+
+            // Reset the ceiling / floor
+            topBid = 0;
+            bottomBid = type(uint256).max;
+
+            // Loop through and find the highest and lowest remaining valid bids
+            for(;i<sortingData.length;) {
+                if (sortingData[i].valid) {
+                    if (sortingData[i].amount > topBid) {
+                        sorted[n] = i;
+                    }
+                    if (sortingData[i].amount < bottomBid) {
+                        sorted[count-1-n] = i;
+                    }
+                }
+            }
+
+            // Mark the lowest & highest bids invalid (Used)
+            sortingData[sorted[n]].valid = false;
+            sortingData[sorted[count-1-n]].valid = false;
+
+            unchecked { invalid +=2; }
+            unchecked { ++n; }
+        }
+
+        return sorted;
+    }
+}

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -40,7 +40,7 @@ contract Sorter {
 
         uint256[] memory sorted = _sort(sortingData, count, invalidCount);
 
-        SearcherCall[] memory searcherCallsSorted = new SearcherCall[](count - invalid);
+        SearcherCall[] memory searcherCallsSorted = new SearcherCall[](count - invalidCount);
 
         count -= invalid;
         uint256 i = 0;

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -42,7 +42,7 @@ contract Sorter {
 
         SearcherCall[] memory searcherCallsSorted = new SearcherCall[](count - invalidCount);
 
-        count -= invalid;
+        count -= invalidCount;
         uint256 i = 0;
 
         for (;i<count;) {

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -150,7 +150,7 @@ contract Sorter {
             unchecked{ ++i; }            
         }
 
-        return (sortingData, invalid);
+        return (sortingData, invalidCount);
     }
 
     function _sort(

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -180,7 +180,7 @@ contract Sorter {
                         sorted[n] = i;
                     }
                     if (sortingData[i].amount < bottomBid) {
-                        sorted[count-1-n] = i;
+                        sorted[count-invalid-1-n] = i;
                     }
                 }
                 unchecked {++i;}

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -11,7 +11,7 @@ import "../types/CallTypes.sol";
 import {CallBits} from "../libraries/CallBits.sol";
 import {CallVerification} from "../libraries/CallVerification.sol";
 
-contract Sequencer {
+contract Sorter {
 
     address immutable public atlas;
     address immutable public escrow;
@@ -26,7 +26,7 @@ contract Sequencer {
         bool valid;
     }
 
-    function sequence(
+    function sortBids(
         UserCall calldata userCall, 
         SearcherCall[] calldata searcherCalls
     ) external view returns (SearcherCall[] memory) {
@@ -183,6 +183,7 @@ contract Sequencer {
                         sorted[count-1-n] = i;
                     }
                 }
+                unchecked {++i;}
             }
 
             // Mark the lowest & highest bids invalid (Used)

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -128,7 +128,7 @@ contract Sorter {
         SortingData[] memory sortingData = new SortingData[](count);
 
         uint256 i;
-        uint256 invalid;
+        uint256 invalidCount;
         for (;i<count;) {
             if (
                 _verifyBidFormat(bidFormat, searcherCalls[i]) && 

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -145,7 +145,7 @@ contract Sorter {
                     amount: 0,
                     valid: false
                 });
-                unchecked{ ++invalid; }
+                unchecked{ ++invalidCount; }
             }
             unchecked{ ++i; }            
         }

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -38,7 +38,7 @@ contract Sorter {
         (SortingData[] memory sortingData, uint256 invalidCount) = _getSortingData(
             protocolCall, userCall, searcherCalls, count);
 
-        uint256[] memory sorted = _sort(sortingData, count, invalid);
+        uint256[] memory sorted = _sort(sortingData, count, invalidCount);
 
         SearcherCall[] memory searcherCallsSorted = new SearcherCall[](count - invalid);
 

--- a/src/contracts/atlas/Sorter.sol
+++ b/src/contracts/atlas/Sorter.sol
@@ -35,7 +35,7 @@ contract Sorter {
 
         uint256 count = searcherCalls.length;
 
-        (SortingData[] memory sortingData, uint256 invalid) = _getSortingData(
+        (SortingData[] memory sortingData, uint256 invalidCount) = _getSortingData(
             protocolCall, userCall, searcherCalls, count);
 
         uint256[] memory sorted = _sort(sortingData, count, invalid);

--- a/src/contracts/interfaces/IEscrow.sol
+++ b/src/contracts/interfaces/IEscrow.sol
@@ -6,4 +6,6 @@ interface IEscrow {
     function cumulativeDonations() external view returns (uint256);
     function deposit(address searcherMetaTxSigner) external payable returns (uint256 newBalance);
     function nextSearcherNonce(address searcherMetaTxSigner) external view returns (uint256 nextNonce);
+    function searcherEscrowBalance(address searcherMetaTxSigner) external view returns (uint256 balance);
+    function searcherLastActiveBlock(address searcherMetaTxSigner) external view returns (uint256 lastBlock);
 }

--- a/src/contracts/interfaces/IProtocolControl.sol
+++ b/src/contracts/interfaces/IProtocolControl.sol
@@ -7,7 +7,7 @@ interface IProtocolControl {
 
     function validateUserCall(UserMetaTx calldata userMetaTx) external view returns (bool);
 
-    function stagingCall(address to, address from, bytes4 userSelector, bytes calldata userData)
+    function stagingCall(UserMetaTx calldata userMetaTx)
         external
         returns (bytes memory);
 
@@ -27,7 +27,9 @@ interface IProtocolControl {
     
     function getPayeeData(bytes calldata data) external returns (PayeeData[] memory);
 
-    function getBidFormat(bytes calldata data) external returns (BidData[] memory);
+    function getBidFormat(UserMetaTx calldata userMetaTx) external view returns (BidData[] memory);
+
+    function getBidValue(SearcherCall calldata searcherCall) external view returns (uint256);
 
     function getProtocolSignatory() external view returns (address governanceAddress);
 

--- a/src/contracts/protocol/GovernanceControl.sol
+++ b/src/contracts/protocol/GovernanceControl.sol
@@ -40,7 +40,7 @@ abstract contract GovernanceControl {
     //
     // Protocol exposure: Trustless
     // User exposure: Trustless
-    function _stagingCall(address to, address from, bytes4 userSelector, bytes calldata userData)
+    function _stagingCall(UserMetaTx calldata userMetaTx)
         internal
         virtual
         returns (bytes memory);
@@ -187,7 +187,9 @@ abstract contract GovernanceControl {
         return true;
     }
 
-    function getPayeeData(bytes calldata data) external virtual returns (PayeeData[] memory);
+    function getPayeeData(bytes calldata data) external view virtual returns (PayeeData[] memory);
 
-    function getBidFormat(bytes calldata data) external virtual returns (BidData[] memory);
+    function getBidFormat(UserMetaTx calldata userMetaTx) external view virtual returns (BidData[] memory);
+
+    function getBidValue(SearcherCall calldata searcherCall) external view virtual returns (uint256);
 }

--- a/src/contracts/protocol/ProtocolControl.sol
+++ b/src/contracts/protocol/ProtocolControl.sol
@@ -105,14 +105,14 @@ abstract contract ProtocolControl is Test, GovernanceControl, ExecutionBase {
         _;
     }
 
-    function stagingCall(address to, address from, bytes4 userSelector, bytes calldata userData)
+    function stagingCall(UserMetaTx calldata userMetaTx)
         external
         mustBeDelegated
         onlyApprovedDelegateCaller
         validControl
         returns (bytes memory)
     {
-        return _stagingCall(to, from, userSelector, userData);
+        return _stagingCall(userMetaTx);
     }
 
     function userLocalCall(bytes calldata data) 

--- a/test/MainTest.t.sol
+++ b/test/MainTest.t.sol
@@ -47,19 +47,25 @@ contract MainTest is BaseTest {
         bytes memory searcherCallData;
         // First SearcherCall
         searcherCallData = helper.buildV2SearcherCallData(POOL_TWO, POOL_ONE);
-        searcherCalls[0] =
+        searcherCalls[1] =
             helper.buildSearcherCall(userCall, protocolCall, searcherCallData, searcherOneEOA, address(searcherOne), 2e17);
 
         (v, r, s) = vm.sign(searcherOnePK, IAtlas(address(atlas)).getSearcherPayload(searcherCalls[0].metaTx));
-        searcherCalls[0].signature = abi.encodePacked(r, s, v);
+        searcherCalls[1].signature = abi.encodePacked(r, s, v);
 
         // Second SearcherCall
         searcherCallData = helper.buildV2SearcherCallData(POOL_ONE, POOL_TWO);
-        searcherCalls[1] =
+        searcherCalls[0] =
             helper.buildSearcherCall(userCall, protocolCall, searcherCallData, searcherTwoEOA, address(searcherTwo), 1e17);
 
         (v, r, s) = vm.sign(searcherTwoPK, IAtlas(address(atlas)).getSearcherPayload(searcherCalls[1].metaTx));
-        searcherCalls[1].signature = abi.encodePacked(r, s, v);
+        searcherCalls[0].signature = abi.encodePacked(r, s, v);
+
+        console.log("topBid before sorting",searcherCalls[0].bids[0].bidAmount);
+        
+        searcherCalls = sorter.sortBids(userCall, searcherCalls);
+
+        console.log("topBid after sorting ",searcherCalls[0].bids[0].bidAmount);
 
         // Verification call
         Verification memory verification =

--- a/test/MainTest.t.sol
+++ b/test/MainTest.t.sol
@@ -44,17 +44,19 @@ contract MainTest is BaseTest {
         userCall.signature = abi.encodePacked(r, s, v);
 
         SearcherCall[] memory searcherCalls = new SearcherCall[](2);
-
+        bytes memory searcherCallData;
         // First SearcherCall
+        searcherCallData = helper.buildV2SearcherCallData(POOL_TWO, POOL_ONE);
         searcherCalls[0] =
-            helper.buildSearcherCall(userCall, protocolCall, searcherOneEOA, address(searcherOne), POOL_ONE, POOL_TWO, 2e17);
+            helper.buildSearcherCall(userCall, protocolCall, searcherCallData, searcherOneEOA, address(searcherOne), 2e17);
 
         (v, r, s) = vm.sign(searcherOnePK, IAtlas(address(atlas)).getSearcherPayload(searcherCalls[0].metaTx));
         searcherCalls[0].signature = abi.encodePacked(r, s, v);
 
         // Second SearcherCall
+        searcherCallData = helper.buildV2SearcherCallData(POOL_ONE, POOL_TWO);
         searcherCalls[1] =
-            helper.buildSearcherCall(userCall, protocolCall, searcherTwoEOA, address(searcherTwo), POOL_TWO, POOL_ONE, 1e17);
+            helper.buildSearcherCall(userCall, protocolCall, searcherCallData, searcherTwoEOA, address(searcherTwo), 1e17);
 
         (v, r, s) = vm.sign(searcherTwoPK, IAtlas(address(atlas)).getSearcherPayload(searcherCalls[1].metaTx));
         searcherCalls[1].signature = abi.encodePacked(r, s, v);

--- a/test/V2Helper.sol
+++ b/test/V2Helper.sol
@@ -55,22 +55,10 @@ contract V2Helper is Test, TestConstants, TxBuilder {
         data = abi.encodeWithSelector(IUniswapV2Pair.swap.selector, amount0Out, amount1Out, recipient, data);
     }
 
-    function buildSearcherCall(
-        UserCall memory userCall,
-        ProtocolCall memory protocolCall,
-        address searcherEOA,
-        address searcherContract,
+    function buildV2SearcherCallData(
         address poolOne,
-        address poolTwo,
-        uint256 bidAmount
-    ) public returns (SearcherCall memory searcherCall) {
-        return TxBuilder.buildSearcherCall(
-            userCall, 
-            protocolCall, 
-            abi.encodeWithSelector(BlindBackrun.executeArbitrage.selector, poolOne, poolTwo),
-            searcherEOA, 
-            searcherContract,  
-            bidAmount
-        );
+        address poolTwo
+    ) public pure returns (bytes memory data) {
+        data = abi.encodeWithSelector(BlindBackrun.executeArbitrage.selector, poolOne, poolTwo);
     }
 }

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -7,6 +7,7 @@ import {IEscrow} from "../../src/contracts/interfaces/IEscrow.sol";
 import {IProtocolIntegration} from "../../src/contracts/interfaces/IProtocolIntegration.sol";
 
 import {Atlas} from "../../src/contracts/atlas/Atlas.sol";
+import {Sorter} from "../../src/contracts/atlas/Sorter.sol";
 
 import {Searcher} from "../searcher/src/TestSearcher.sol";
 
@@ -36,6 +37,8 @@ contract BaseTest is Test, TestConstants {
     Atlas public atlas;
     address public escrow;
 
+    Sorter public sorter;
+
     Searcher public searcherOne;
     Searcher public searcherTwo;
 
@@ -61,6 +64,7 @@ contract BaseTest is Test, TestConstants {
 
         atlas = new Atlas(64);
         escrow = atlas.getEscrowAddress();
+        sorter = new Sorter(address(atlas), escrow);
 
         vm.stopPrank();
         vm.startPrank(governanceEOA);


### PR DESCRIPTION
A "helper" contract to sort searcher bids in an unsophisticated manner.  Each ProtocolControl can now override a "getBidValue" function that returns a uint256 that can be used to sort.   In an upcoming version of Atlas, a "sortOnChain" config option will allow on-chain sorting.  In a VERY distant version, searcher intents can accrue onchain and then be executed by the User after using the "sortOnChain" function... note that this feature probably won't be used on chains w/ costly compute such as ethereum. 